### PR TITLE
MaxJSONSize and MaxXMLSize must be greater than zero

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -77,7 +77,7 @@ func (t *Tools) ReadJSON(w http.ResponseWriter, r *http.Request, data interface{
 	maxBytes := defaultMaxUpload
 
 	// If MaxJSONSize is set, use that value instead of default.
-	if t.MaxJSONSize != 0 {
+	if t.MaxJSONSize > 0 {
 		maxBytes = t.MaxJSONSize
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))
@@ -411,7 +411,7 @@ func (t *Tools) ReadXML(w http.ResponseWriter, r *http.Request, data interface{}
 	maxBytes := defaultMaxUpload
 
 	// If MaxXMLSize is set, use that value instead of default.
-	if t.MaxXMLSize != 0 {
+	if t.MaxXMLSize > 0 {
 		maxBytes = t.MaxXMLSize
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))


### PR DESCRIPTION
Hello,

I have thoroughly enjoyed watching almost all of your courses on Udemy. First and foremost, thank you very, very much for these valuable lessons.

I was following your Tools package course, and a question arose in my mind regarding Json. Therefore, I forked the Toolbox project and tested the issue that puzzled me.

It seems that if MaxJSONSize and MaxXMLSize values are not equal to zero, they are being paired with defaultMaxUpload. In the tests, since these values are always positive numbers, the tests were successful. However, when a negative value was entered, it was not equal to zero, so the entered negative value was assigned, causing the tests to fail.

Therefore, instead of checking whether MaxJSONSize and MaxXMLSize values are equal to zero, I checked whether they are greater than zero. This way, even if a negative value is entered, the tests are successful. Of course, alternatively, it could be considered to return an error by checking whether MaxJSONSize and MaxXMLSize values are less than zero. You know better which approach is more effective.

Since there is no explanation about contributing, I hesitated about the pull request. Nevertheless, I thought I would try my luck.